### PR TITLE
Misc slope/roo handling fixes.

### DIFF
--- a/Source/Core/Map/Sector.cs
+++ b/Source/Core/Map/Sector.cs
@@ -124,9 +124,9 @@ namespace CodeImp.DoomBuilder.Map
 		/// An unique index that does not change when other sectors are removed.
 		/// </summary>
 		public int FixedIndex { get { return fixedindex; } }
-		public int FloorHeight { get { return floorheight; } set { BeforePropsChange(); floorheight = value; } }
-		public int CeilHeight { get { return ceilheight; } set { BeforePropsChange(); ceilheight = value; } }
-		// M59 wants the offsets as unsigned short.
+		// M59 wants the offsets and heights as unsigned short.
+		public int FloorHeight { get { return floorheight; } set { BeforePropsChange(); floorheight = Math.Max(Math.Min(value, ushort.MaxValue), 0); } }
+		public int CeilHeight { get { return ceilheight; } set { BeforePropsChange(); ceilheight = Math.Max(Math.Min(value, ushort.MaxValue), 0); } }
 		public int OffsetX { get { return offsetx; } set { BeforePropsChange(); offsetx = Math.Max(Math.Min(value, ushort.MaxValue), 0); } }
 		public int OffsetY { get { return offsety; } set { BeforePropsChange(); offsety = Math.Max(Math.Min(value, ushort.MaxValue), 0); } }
 		public string FloorTexture { get { return floortexname; } }

--- a/Source/Core/Properties/AssemblyInfo.cs
+++ b/Source/Core/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Resources;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.3.0.2664")]
+[assembly: AssemblyVersion("2.3.0.2665")]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/Source/Plugins/BuilderModes/Properties/AssemblyInfo.cs
+++ b/Source/Plugins/BuilderModes/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Resources;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.3.0.2664")]
+[assembly: AssemblyVersion("2.3.0.2665")]
 [assembly: NeutralResourcesLanguageAttribute("en")]


### PR DESCRIPTION
- Don't lower floor or ceiling below 0 units.
- Double check for a valid kod slope (3 referenced vertexes) before
  writing, and don't write the slope if any data is missing. Log an error
  if this happens.
- Round floats before casting to int, to avoid cases where we floor
  rather than round up by 0.01. Fixes some rare off-by-one slope heights.
